### PR TITLE
Fix database migration on plugin updates

### DIFF
--- a/wp-mux-livestream.php
+++ b/wp-mux-livestream.php
@@ -42,7 +42,6 @@ function check_database_version() {
 	
 	if ( $installed_db_version !== WP_MUX_LIVESTREAM_DB_VERSION ) {
 		create_db_table();
-		update_option( 'wp_mux_livestream_db_version', WP_MUX_LIVESTREAM_DB_VERSION );
 	}
 }
 


### PR DESCRIPTION
Previously, database migrations only ran during plugin activation, causing issues when users updated the plugin. This fix adds automatic version checking that runs database migrations whenever needed.

Resolves #1